### PR TITLE
Converted seeded data into factories

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,43 +5,11 @@ institution = Institution.find_or_create_by!(id: 1) do |inst|
   inst.name = 'North Carolina State University'
 end
 
-# Create users for each role type
-User.find_or_create_by!(email: 'student@ncsu.edu') do |student|
-  student.name = 'student'
-  student.password = 'password123'
-  student.full_name = 'student student'
-  student.institution = institution
-  student.role = Role.find_by(name: 'Student')
-end
-
-User.find_or_create_by!(email: 'ta@ncsu.edu') do |ta|
-  ta.name = 'ta'
-  ta.password = 'password123'
-  ta.full_name = 'ta ta'
-  ta.institution = institution
-  ta.role = Role.find_by(name: 'Teaching Assistant')
-end
-
-User.find_or_create_by!(email: 'instructor@ncsu.edu') do |instructor|
-  instructor.name = 'instructor'
-  instructor.password = 'password123'
-  instructor.full_name = 'instructor instructor'
-  instructor.institution = institution
-  instructor.role = Role.find_by(name: 'Instructor')
-end
-
+# Keep an admin for testing purposes
 User.find_or_create_by!(email: 'admin@ncsu.edu') do |admin|
   admin.name = 'admin'
   admin.password = 'password123'
   admin.full_name = 'admin admin'
   admin.institution = institution
   admin.role = Role.find_by(name: 'Administrator')
-end
-
-User.find_or_create_by!(email: 'super_admin@ncsu.edu') do |super_admin|
-  super_admin.name = 'super_admin'
-  super_admin.password = 'password123'
-  super_admin.full_name = 'super_admin super_admin'
-  super_admin.institution = institution
-  super_admin.role = Role.find_by(name: 'Super Administrator')
 end

--- a/spec/factories/role.rb
+++ b/spec/factories/role.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
     factory :role do
-        # Default to student (role_id: 5)
-        id { 5 }
+        id { Role.find_by(name: 'Student').id || 5 }
+        name { 'Student' } # Adjust this as needed
     end
-end
+  end
+  

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,9 +2,13 @@ FactoryBot.define do
     factory :user do
         sequence(:name) { |_n| Faker::Name.name.to_s.delete(" \t\r\n").downcase }
         sequence(:email) { |_n| Faker::Internet.email.to_s }
-        password { 'password' }
-        sequence(:full_name) { |_n| "#{Faker::Name.name}#{Faker::Name.name}".downcase }
-        role factory: :role
-        institution factory: :institution
+        password { 'password123' }
+        sequence(:full_name) { |_n| "#{Faker::Name.name} #{Faker::Name.name}".downcase }
+    
+        # Use the existing 'Student' role if available
+        role { Role.find_by(name: 'Student') || association(:role, name: 'Student') }
+
+        # Use the existing 'North Carolina State University' institution if available
+        institution { Institution.find_by(name: 'North Carolina State University') || association(:institution, name: 'North Carolina State University') }
     end
 end

--- a/spec/requests/api/v1/bookmarks_controller_spec.rb
+++ b/spec/requests/api/v1/bookmarks_controller_spec.rb
@@ -2,60 +2,93 @@ require 'rails_helper'
 require 'factory_bot_rails' # shouldn't be needed
 
 RSpec.describe 'api/v1/bookmarks', type: :request do
-  # Find each user in the users table
-  # We can look it up by the role_id
-  let(:student) { User.find_by(name: 'student') }
-  let(:ta) { User.find_by(name: 'ta') }
-  let(:instructor) { User.find_by(name: 'instructor') }
-  let(:admin) { User.find_by(name: 'admin') }
-  let(:super_admin) { User.find_by(name: 'super_admin') }
-
-  # Create headers for each user so they can sign in
-  let(:student_headers) { authenticated_header(student) }
-  let(:ta_headers) { authenticated_header(ta) }
-  let(:instructor_headers) { authenticated_header(instructor) }
-  let(:admin_headers) { authenticated_header(admin) }
-  let(:super_admin_headers) { authenticated_header(super_admin) }
 
   before do
     # Set the default host to localhost
     host! 'localhost'
   end
-  
-  describe 'GET /api/v1/bookmarks' do
-    it 'lets the student access the list of bookmarks' do
-      get '/api/v1/bookmarks', headers: student_headers
-      expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq([])
-    end
 
-    it 'lets the ta access the list of bookmarks' do
-      get '/api/v1/bookmarks', headers: ta_headers
-      expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq([])
+  describe User do 
+    before(:each) do
+      # Create a student
+      @student = create(:user, role_id: Role.find_by(name: 'Student').id)
+      @student_headers = authenticated_header(@student)
     end
-
-    it 'lets the instructor access the list of bookmarks' do
-      get '/api/v1/bookmarks', headers: instructor_headers
-      expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq([])
+    describe 'GET /api/v1/bookmarks' do
+      it 'lets the student access the list of bookmarks' do
+        get '/api/v1/bookmarks', headers: @student_headers
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq([])
+      end
     end
+  end
 
-    it 'lets the admin access the list of bookmarks' do
-      get '/api/v1/bookmarks', headers: admin_headers
-      expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq([])
+  describe Ta do
+    before(:each) do
+      # Create a teaching assistant
+      @ta = create(:user, role_id: Role.find_by(name: 'Teaching Assistant').id)
+      @ta_headers = authenticated_header(@ta)
     end
-
-    it 'lets the super admin access the list of bookmarks' do
-      get '/api/v1/bookmarks', headers: super_admin_headers
-      expect(response).to have_http_status(:ok)
-      expect(JSON.parse(response.body)).to eq([])
+    describe 'GET /api/v1/bookmarks' do
+      it 'lets the teaching assistant access the list of bookmarks' do
+        get '/api/v1/bookmarks', headers: @ta_headers
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq([])
+      end
     end
+  end
 
-    it 'does not let someone without a token access the list of bookmarks' do
-      get '/api/v1/bookmarks'
-      expect(response).to have_http_status(:unauthorized)
+  describe Instructor do
+    before(:each) do
+      # Create an instructor
+      @instructor = create(:user, role_id: Role.find_by(name: 'Instructor').id)
+      @instructor_headers = authenticated_header(@instructor)
+    end
+    describe 'GET /api/v1/bookmarks' do
+      it 'lets the instructor access the list of bookmarks' do
+        get '/api/v1/bookmarks', headers: @instructor_headers
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq([])
+      end
+    end
+  end
+
+  describe Administrator do
+    before(:each) do
+      # Create an administrator
+      @admin = create(:user, role_id: Role.find_by(name: 'Administrator').id)
+      @admin_headers = authenticated_header(@admin)
+    end
+    describe 'GET /api/v1/bookmarks' do
+      it 'lets the administrator access the list of bookmarks' do
+        get '/api/v1/bookmarks', headers: @admin_headers
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq([])
+      end
+    end
+  end
+
+  describe SuperAdministrator do
+    before(:each) do
+      # Create a super administrator
+      @super_admin = create(:user, role_id: Role.find_by(name: 'Super Administrator').id)
+      @super_admin_headers = authenticated_header(@super_admin)
+    end
+    describe 'GET /api/v1/bookmarks' do
+      it 'lets the super administrator access the list of bookmarks' do
+        get '/api/v1/bookmarks', headers: @super_admin_headers
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)).to eq([])
+      end
+    end
+  end
+
+  describe 'user that has not signed in' do
+    describe 'GET /api/v1/bookmarks' do
+      it 'does not let someone without a token access the list of bookmarks' do
+        get '/api/v1/bookmarks'
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
   end
 end


### PR DESCRIPTION
While having data seeded directly into the database can be convenient, there isn't a need to have it in the database if a large portion of the tests aren't using that data. I was able to get the User factory working so that Users could be created on the fly instead of needing to be seeded.